### PR TITLE
remove dependency review as needs diff

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -19,12 +19,10 @@ jobs:
 
   test:
     uses: ./.github/workflows/test-workflow.yml
-  
-  dependency-review:    
-    uses: ./.github/workflows/dependency-review.yml
+
 
   publish:
-    needs: [test, dependency-review, codeql]
+    needs: [test, codeql]
     runs-on: ubuntu-latest
     environment: 
       name: 'published'

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -6,7 +6,7 @@
 # Public documentation: https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review#dependency-review-enforcement
 name: 'Dependency Review'
 on:
-  workflow_call:
+  pull-request:
 
 permissions:
   contents: read


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request removes the dependency review step from the CI workflow, simplifying the build and publish process.

- **CI**:
    - Removed the dependency review step from the CI workflow.

<!-- Generated by sourcery-ai[bot]: end summary -->