### PR TITLE
update reonvate to be less busy

### DIFF
--- a/.github/workflows/deploy_build_artifact.yaml
+++ b/.github/workflows/deploy_build_artifact.yaml
@@ -21,6 +21,9 @@ jobs:
     permissions:                # Job-level permissions configuration starts here
       contents: read           # 'write' access to repository contents
       actions: read
+      id-token: write
+      attestations: write
+
     steps:
 
       - name: check out code
@@ -60,6 +63,12 @@ jobs:
 
           poetry build
 
+      - name: attest artifacts
+        id: attest-artifacts
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: 'dist/*'
+
       - name: Upload build artifact
         id: upload-artifact
         uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4
@@ -67,7 +76,11 @@ jobs:
           compression-level: 0 # no compression
           if-no-files-found: error
           name: ${{ steps.Build.outputs.artifact_name }}
-          path: dist/
+          path: |
+            dist/
+            ${{ steps.attest-artifacts.outputs.bundle-path }}
+
+
 
     outputs:
       artifact-url: ${{ steps.upload-artifact.outputs.artifact-url }}

--- a/.github/workflows/deploy_to_pypi.yml
+++ b/.github/workflows/deploy_to_pypi.yml
@@ -18,7 +18,7 @@ on:
 
 
 jobs:
-  deploy_to_pypi_test:
+  deploy_to_pypi:
     runs-on: ubuntu-latest
     permissions:
       # IMPORTANT: this permission is mandatory for trusted publishing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,8 @@ license = "MIT"
 readme = "README.md"
 homepage = "https://github.com/mnbf9rca/pydantic_tfl_api"
 repository = "https://github.com/mnbf9rca/pydantic_tfl_api"
+keywords = ["pydantic", "tfl", "tfl-api", "transport-for-london", "unified-api"]
+
 
 [tool.poetry.dependencies]
 python = "^3.12"

--- a/renovate.json
+++ b/renovate.json
@@ -1,42 +1,28 @@
 {
-    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": [
-      "config:best-practices"
-    ],
-    "automerge": true,
-    "automergeType": "pr",
-    "ignoreTests": false,
-    "lockFileMaintenance": {
-      "enabled": true,
-      "extends": [
-        "schedule:weekly"
-      ],
-      "automerge": true
-    },
-    "minor": {
-      "automerge": true,
-      "extends": [
-        "schedule:automergeDaily"
-      ]
-    },
-    "patch": {
-      "automerge": true,
-      "extends": [
-        "schedule:automergeDaily"
-      ]
-    },
-    "pin": {
-      "automerge": true,
-      "extends": [
-        "schedule:automergeDaily"
-      ]
-    },
-    "vulnerabilityAlerts": {
-      "enabled": true,
-      "extends": [
-        "schedule:daily"
-      ]
-    },
-    "rebaseWhen": "behind-base-branch",
-    "updateNotScheduled": true
-  }
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "rangeStrategy": "widen",
+  "packageRules": [
+      {
+          "depTypeList": ["dependencies"],
+          "updateTypes": ["patch", "minor", "major"],
+          "automerge": false
+      },
+      {
+          "depTypeList": ["devDependencies"],
+          "automerge": false
+      },
+      {
+          "vulnerabilityAlerts": true,
+          "automerge": true,
+          "schedule": ["automergeDaily"]
+      }
+  ],
+  "lockFileMaintenance": {
+    "enabled": false
+  },
+  "rebaseWhen": "behind-base-branch",
+  "updateNotScheduled": true
+}


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request updates the Renovate configuration to reduce the frequency of updates and modifies CI workflows to include artifact attestation and adjust job permissions.

- **Enhancements**:
    - Updated Renovate configuration to use 'config:recommended' and adjusted package rules to reduce the frequency of updates.
    - Disabled lock file maintenance in Renovate configuration.
- **CI**:
    - Added 'id-token' and 'attestations' permissions to the deploy_build_artifact workflow.
    - Included a step to attest artifacts in the deploy_build_artifact workflow.
    - Updated the deploy_to_pypi workflow to remove the '_test' suffix from the job name.

<!-- Generated by sourcery-ai[bot]: end summary -->