### PR TITLE
Feat/add ttl to response

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,21 @@ print (client.get_route_by_line_id_with_direction(line_id="northern", direction=
 
 The Pydantic classes are in the `tfl.models` module. The `tfl.client` module contains the `Client` class, which is the main class you will use to interact with the API.
 
-Pydantic models are used to represent the data returned by the TfL API. There is a circular reference in the TfL API, so I handled this in the `StopPoint` model to load the `Line` model only after `StopPoint` is fully loaded. Here's a visualisation of the Pydantic models:
+Pydantic models are used to represent the data returned by the TfL API. There is a circular reference in the TfL API, so I handled this in the `StopPoint` model to load the `Line` model only after `StopPoint` is fully loaded.
+
+The following objects represent responses from the TfL API, and are therefore returned by the `Client` class methods - either individually or as an array of objects:
+
+- `StopPoint`
+- `Mode`
+- `Line`
+- `RouteSequence`
+- `Disruption`
+- `StopPointsResponse`
+- `Prediction`
+
+These objects contains a property `content_expires` which is a `. This is calculated from the headers of the response. You can use these to calculate the time to live of the object, and to determine if the object is still valid - for example if implementing caching.
+
+Here's a Mermaid visualisation of the Pydantic models:
 
 ```mermaid
 classDiagram

--- a/pydantic_tfl_api/client.py
+++ b/pydantic_tfl_api/client.py
@@ -31,6 +31,8 @@ from requests import Response
 import pkgutil
 from pydantic import BaseModel
 from . import models
+from datetime import datetime, timedelta
+from email.utils import parsedate_to_datetime
 
 
 class Client:
@@ -54,15 +56,56 @@ class Client:
         # print(models_dict)
         return models_dict
 
+    def _get_s_maxage_from_cache_control_header(self, response: Response) -> int | None:
+        cache_control = response.headers.get("cache-control")
+        # e.g. 'public, must-revalidate, max-age=43200, s-maxage=86400'
+        if cache_control is None:
+            return None
+        directives = cache_control.split(" ")
+        # e.g. ['public,', 'must-revalidate,', 'max-age=43200,', 's-maxage=86400']
+        directives = {d.split("=")[0]: d.split("=")[1] for d in directives if "=" in d}
+        if "s-maxage" not in directives:
+            return None
+        return int(directives["s-maxage"])
+
+    def _get_result_expiry(self, response: Response) -> datetime | None:
+        s_maxage = self._get_s_maxage_from_cache_control_header(response)
+        if s_maxage:
+            request_datetime = parsedate_to_datetime(response.headers.get("date"))
+            return request_datetime + timedelta(seconds=s_maxage)
+
     def _deserialize(self, model_name: str, response: Response) -> Any:
+        result_expiry = self._get_result_expiry(response)
+        Model = self._get_model(model_name)
+        data = response.json()
+
+        result = self._create_model_instance(Model, data, result_expiry)
+
+        return result
+
+    def _get_model(self, model_name: str) -> BaseModel:
         Model = self.models.get(model_name)
         if Model is None:
             raise ValueError(f"No model found with name {model_name}")
-        data = response.json()
-        if isinstance(data, list):
-            return [Model(**item) for item in data]
+        return Model
+
+    def _create_model_instance(
+        self, Model: BaseModel, response_json: Any, result_expiry: datetime
+    ):
+        if isinstance(response_json, dict):
+            return self._create_model_with_expiry(Model, response_json, result_expiry)
         else:
-            return Model(**data)
+            return [
+                self._create_model_with_expiry(Model, item, result_expiry)
+                for item in response_json
+            ]
+
+    def _create_model_with_expiry(
+        self, Model: BaseModel, response_json: Any, result_expiry: datetime
+    ):
+        instance = Model(**response_json)
+        instance.content_expires = result_expiry
+        return instance
 
     def _deserialize_error(self, response: Response) -> models.ApiError:
         # if content is json, deserialize it, otherwise manually create an ApiError object

--- a/pydantic_tfl_api/models/disruption.py
+++ b/pydantic_tfl_api/models/disruption.py
@@ -1,9 +1,10 @@
 from pydantic import BaseModel, Field
 from datetime import datetime
-from typing import List
+from typing import List, Optional
 
 from .affected_route import AffectedRoute
 from .stop_point import StopPoint
+
 
 class Disruption(BaseModel):
     category: str = Field(alias='category')
@@ -17,6 +18,7 @@ class Disruption(BaseModel):
     affected_routes: List[AffectedRoute] = Field(alias='affectedRoutes')
     affected_stops: List[StopPoint] = Field(alias='affectedStops')
     closure_text: str = Field(alias='closureText')
+    content_expires: Optional[datetime] = Field(None)
 
     model_config = {'populate_by_name': True}
 

--- a/pydantic_tfl_api/models/line.py
+++ b/pydantic_tfl_api/models/line.py
@@ -19,5 +19,6 @@ class Line(BaseModel):
     route_sections: List[RouteSection] = Field(None, alias='routeSections')
     service_types: List[ServiceType] = Field(None, alias='serviceTypes')
     crowding: Optional[Crowding] = Field(None, alias='crowding')
+    content_expires: Optional[datetime] = Field(None)
 
     model_config = {'populate_by_name': True}

--- a/pydantic_tfl_api/models/line.py
+++ b/pydantic_tfl_api/models/line.py
@@ -8,16 +8,17 @@ from .route_section import RouteSection
 from .service_type import ServiceType
 from .crowding import Crowding
 
+
 class Line(BaseModel):
     id: str = Field(alias='id')
     name: str = Field(alias='name')
-    mode_name: str = Field(None, alias='modeName')
+    mode_name: Optional[str] = Field(None, alias='modeName')
     disruptions: Optional[List[Disruption]] = Field([], alias='disruptions')
     created: Optional[datetime] = Field(None, alias='created')
     modified: Optional[datetime] = Field(None, alias='modified')
-    line_statuses: List[LineStatus] = Field(None, alias='lineStatuses')
-    route_sections: List[RouteSection] = Field(None, alias='routeSections')
-    service_types: List[ServiceType] = Field(None, alias='serviceTypes')
+    line_statuses: Optional[List[LineStatus]] = Field(None, alias='lineStatuses')
+    route_sections: Optional[List[RouteSection]] = Field(None, alias='routeSections')
+    service_types: Optional[List[ServiceType]] = Field(None, alias='serviceTypes')
     crowding: Optional[Crowding] = Field(None, alias='crowding')
     content_expires: Optional[datetime] = Field(None)
 

--- a/pydantic_tfl_api/models/line.py
+++ b/pydantic_tfl_api/models/line.py
@@ -11,13 +11,13 @@ from .crowding import Crowding
 class Line(BaseModel):
     id: str = Field(alias='id')
     name: str = Field(alias='name')
-    mode_name: str = Field(alias='modeName')
+    mode_name: str = Field(None, alias='modeName')
     disruptions: Optional[List[Disruption]] = Field([], alias='disruptions')
     created: Optional[datetime] = Field(None, alias='created')
     modified: Optional[datetime] = Field(None, alias='modified')
-    line_statuses: List[LineStatus] = Field(alias='lineStatuses')
-    route_sections: List[RouteSection] = Field(alias='routeSections')
-    service_types: List[ServiceType] = Field(alias='serviceTypes')
+    line_statuses: List[LineStatus] = Field(None, alias='lineStatuses')
+    route_sections: List[RouteSection] = Field(None, alias='routeSections')
+    service_types: List[ServiceType] = Field(None, alias='serviceTypes')
     crowding: Optional[Crowding] = Field(None, alias='crowding')
 
     model_config = {'populate_by_name': True}

--- a/pydantic_tfl_api/models/mode.py
+++ b/pydantic_tfl_api/models/mode.py
@@ -1,9 +1,12 @@
 from pydantic import BaseModel, Field
+from datetime import datetime
+from typing import Optional
 
 class Mode(BaseModel):
     is_tfl_service: bool = Field(alias='isTflService')
     is_fare_paying: bool = Field(alias='isFarePaying')
     is_scheduled_service: bool = Field(alias='isScheduledService')
     mode_name: str = Field(alias='modeName')
+    content_expires: Optional[datetime] = Field(None)
 
     model_config = {'populate_by_name': True}

--- a/pydantic_tfl_api/models/prediction.py
+++ b/pydantic_tfl_api/models/prediction.py
@@ -25,5 +25,6 @@ class Prediction(BaseModel):
     time_to_live: datetime = Field(alias='timeToLive')
     mode_name: str = Field(alias='modeName')
     timing: PredictionTiming = Field(alias='timing')
+    content_expires: Optional[datetime] = Field(None)
 
     model_config = {'populate_by_name': True}

--- a/pydantic_tfl_api/models/route_sequence.py
+++ b/pydantic_tfl_api/models/route_sequence.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel, Field
 from typing import Optional
+from datetime import datetime
 
 from .matched_stop import MatchedStop
 from .ordered_route import OrderedRoute
@@ -14,5 +15,6 @@ class RouteSequence(BaseModel):
     stations: list[MatchedStop] = Field(alias='stations')
     service_type: Optional[str] = Field(None, alias='serviceType')
     ordered_line_routes: list[OrderedRoute] = Field(alias='orderedLineRoutes')
+    content_expires: Optional[datetime] = Field(None)
     
     model_config = {'populate_by_name': True}

--- a/pydantic_tfl_api/models/stop_point.py
+++ b/pydantic_tfl_api/models/stop_point.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel, Field
 from typing import List, Optional
+from datetime import datetime
 
 
 from .line_group import LineGroup
@@ -16,7 +17,7 @@ class StopPoint(BaseModel):
     modes: List[str] = Field(alias="modes")
     ics_code: Optional[str] = Field(None, alias="icsCode")
     sms_code: Optional[str] = Field(None, alias="smsCode")
-    stop_type: str = Field(alias="stopType")
+    stop_type: str = Field(None, alias="stopType")
     station_naptan: str = Field(alias="stationNaptan")
     accessibility_summary: Optional[str] = Field(None, alias="accessibilitySummary")
     hub_naptan_code: Optional[str] = Field(None, alias="hubNaptanCode")
@@ -36,12 +37,15 @@ class StopPoint(BaseModel):
     )
     children: Optional[List["StopPoint"]] = Field(None, alias="children")
     children_urls: Optional[List[str]] = Field([], alias="childrenUrls")
-    lat: int = Field(alias="lat")
-    lon: int = Field(alias="lon")
+    lat: float = Field(alias="lat")
+    lon: float = Field(alias="lon")
+    content_expires: Optional[datetime] = Field(None)
 
     model_config = {"populate_by_name": True}
 
 
-from .line import Line
+# we have to import Line after StopPoint is defined or we get a circular reference
+from .line import Line  # noqa: E402
 
+# Rebuild the model to reference Line
 StopPoint.model_rebuild()

--- a/pydantic_tfl_api/models/stop_point.py
+++ b/pydantic_tfl_api/models/stop_point.py
@@ -17,7 +17,7 @@ class StopPoint(BaseModel):
     modes: List[str] = Field(alias="modes")
     ics_code: Optional[str] = Field(None, alias="icsCode")
     sms_code: Optional[str] = Field(None, alias="smsCode")
-    stop_type: str = Field(None, alias="stopType")
+    stop_type: Optional[str] = Field(None, alias="stopType")
     station_naptan: str = Field(alias="stationNaptan")
     accessibility_summary: Optional[str] = Field(None, alias="accessibilitySummary")
     hub_naptan_code: Optional[str] = Field(None, alias="hubNaptanCode")

--- a/pydantic_tfl_api/models/stop_points_response.py
+++ b/pydantic_tfl_api/models/stop_points_response.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel, Field
 from typing import List, Optional
+from datetime import datetime
 
 from .stop_point import StopPoint
 
@@ -8,5 +9,6 @@ class StopPointsResponse(BaseModel):
     page_size: int = Field(alias='pageSize')
     total: int = Field(alias='total')
     page: int = Field(alias='page')
+    content_expires: Optional[datetime] = Field(None)
 
     model_config = {'populate_by_name': True}


### PR DESCRIPTION
resolves #43

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request introduces a TTL (time-to-live) feature for API responses by calculating expiration times from the 'cache-control' header. It also updates the Pydantic models to include a 'content_expires' property and updates the README to document these changes.

- **New Features**:
    - Added TTL (time-to-live) calculation for API responses based on the 'cache-control' header.
- **Enhancements**:
    - Updated Pydantic models to include a 'content_expires' property for tracking TTL.
- **Documentation**:
    - Updated README to document the new 'content_expires' property in response objects and its usage.

<!-- Generated by sourcery-ai[bot]: end summary -->