### PR TITLE
remove app_id from tfl api token as it's not needed any more

### DIFF
--- a/pydantic_tfl_api/api_token.py
+++ b/pydantic_tfl_api/api_token.py
@@ -29,6 +29,5 @@ class ApiToken():
     :param str app_key: Application Key from the API credentails
     """
 
-    def __init__(self, app_id, app_key):
-        self.app_id = app_id
+    def __init__(self, app_key):
         self.app_key = app_key

--- a/pydantic_tfl_api/rest_client.py
+++ b/pydantic_tfl_api/rest_client.py
@@ -36,7 +36,7 @@ class RestClient():
     """
 
     def __init__(self, api_token: ApiToken = None):
-        self.api_token = {"app_id": api_token.app_id, "app_key": api_token.app_key} if api_token else None
+        self.api_token = {"app_key": api_token.app_key} if api_token else None
 
     def send_request(self, location, params=None):
         return requests.get(base_url + location + "?" + self._get_query_strings(params))

--- a/tests/test_basic_tests.py
+++ b/tests/test_basic_tests.py
@@ -5,20 +5,19 @@ from pydantic_tfl_api.models import ApiError, LineStatus, Line
 # to make sure that the pydantic models load
 # and that the TFL API connectivity is ok - although we'll have 
 def test_create_api_token():
-    api_token = ApiToken('your_api_token', 'app_key')
-    assert api_token.app_id == 'your_api_token'
-    assert api_token.app_key == 'app_key'
+    api_token = ApiToken('your_app_key')
+    assert api_token.app_key == 'your_app_key'
 
 def test_create_client_with_api_token():
     # checks that the API key is being passed to the RestClient
-    api_token = ApiToken('your_api_token', 'app_key')
+    api_token = ApiToken('your_app_key')
     client = Client(api_token)
-    assert client.client.api_token['app_id'] == 'your_api_token'
+    assert client.client.api_token['app_key'] == 'your_app_key'
 
 def test_get_line_status_by_mode_rejected_with_invalid_api_key():
-    api_token = ApiToken('your_api_token', 'app_key')
+    api_token = ApiToken('your_app_key')
     client = Client(api_token)
-    assert client.client.api_token['app_id'] == 'your_api_token'    
+    assert client.client.api_token['app_key'] == 'your_app_key'
     # should get a 429 error inside an ApiError object
     result = client.get_line_status_by_mode('overground,tube')
     assert isinstance(result, ApiError)


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Removed the app_id parameter from the ApiToken class and updated the RestClient and associated tests to reflect this change.

- **Tests**:
    - Updated tests to reflect the removal of the app_id parameter from the ApiToken class.

<!-- Generated by sourcery-ai[bot]: end summary -->