### PR TITLE
add response_timestamp field to ResponseModel

### DIFF
--- a/pydantic_tfl_api/core/package_models.py
+++ b/pydantic_tfl_api/core/package_models.py
@@ -9,6 +9,7 @@ T = TypeVar('T', bound=BaseModel)
 class ResponseModel(BaseModel, Generic[T]):
     content_expires: Optional[datetime]
     shared_expires: Optional[datetime]
+    response_timestamp: Optional[datetime]
     content: T  # The content will now be of the specified type
 
     class Config:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pydantic-tfl-api"
-version = "1.0.0"
+version = "1.1.0"
 description = "A Pydantic-based wrapper for the TfL Unified API https://api.tfl.gov.uk/. Not associated with or endorsed by TfL."
 authors = ["Rob Aleck <mnbf9rca@users.noreply.github.com>"]
 license = "MIT"


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add a `response_timestamp` field to the `ResponseModel` to capture the response's timestamp. Enhance the client to extract this timestamp from the response headers and update the deserialization process to include this new field. Introduce tests to ensure the correct handling of the 'Date' header in responses.

New Features:
- Introduce a new field `response_timestamp` in the `ResponseModel` to store the timestamp of the response.

Enhancements:
- Add a static method `_get_datetime_from_response_headers` in the client to extract and parse the 'Date' header from response headers.

Tests:
- Add tests to verify the correct extraction and parsing of the 'Date' header from response headers, including cases for valid, missing, and invalid dates.

<!-- Generated by sourcery-ai[bot]: end summary -->