### PR TITLE
Add attestations flag to PyPI deployment workflow

### DIFF
--- a/.github/workflows/deploy_to_pypi.yml
+++ b/.github/workflows/deploy_to_pypi.yml
@@ -52,6 +52,7 @@ jobs:
           packages-dir: ${{ steps.download-artifact.outputs.download-path }}
           verbose: true
           print-hash: true
+          attestations: true
 
 
     


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add an 'attestations' flag to the PyPI deployment workflow to enhance the deployment process.

Deployment:
- Add an 'attestations' flag to the PyPI deployment workflow configuration.

<!-- Generated by sourcery-ai[bot]: end summary -->