### PR TITLE
remote attestations from pypi publication

### DIFF
--- a/.github/workflows/deploy_to_pypi.yml
+++ b/.github/workflows/deploy_to_pypi.yml
@@ -26,6 +26,18 @@ jobs:
     environment: 
       name: ${{ inputs.target-environment }}
     steps:
+      # - name: Checkout actions-oidc-debugger
+      #   uses: actions/checkout@v3
+      #   with:
+      #     repository: github/actions-oidc-debugger
+      #     ref: main
+      #     token: ${{ github.token }}
+      #     path: ./.github/actions/actions-oidc-debugger
+      # - name: Debug OIDC Claims
+      #   uses: ./.github/actions/actions-oidc-debugger
+      #   with:
+      #     audience: '${{ github.server_url }}/${{ github.repository_owner }}'
+
       - name: get workspacedir
         # see https://github.com/actions/runner/issues/2058#issuecomment-1308554566
         shell: bash
@@ -52,7 +64,7 @@ jobs:
           packages-dir: ${{ steps.download-artifact.outputs.download-path }}
           verbose: true
           print-hash: true
-          attestations: true
+          # attestations: true  # https://github.com/pypi/warehouse/issues/11096
 
 
     

--- a/.github/workflows/deploy_workflow_wrapper.yml
+++ b/.github/workflows/deploy_workflow_wrapper.yml
@@ -1,6 +1,6 @@
 name: build artifact and publish to PyPi
+
 on: 
-  # whenever version is bumped, or allow manual runs
   workflow_dispatch:
     inputs:
       deploy_to_test:
@@ -8,6 +8,7 @@ on:
         description: 'Deploy to PyPi test'
         required: false
         default: false
+
   workflow_run: 
     workflows: ["bump version"]
     types:
@@ -16,23 +17,28 @@ on:
 jobs:
   build_artifacts:
     uses: ./.github/workflows/deploy_build_artifact.yaml
-    # output:
-      # artifact-url:
-      # artifact-id:
-      # package-version:
-      # artifact-name:
 
   deploy_to_pypi_test:
     needs: [build_artifacts]
-    if: ${{ github.event.inputs.deploy_to_test == true }}
+    if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_to_test == 'true' }}
     uses: ./.github/workflows/deploy_to_pypi.yml
     with:
       package-version: ${{ needs.build_artifacts.outputs.package-version }}
       target-environment: 'pypi-test'
       artifact-name: ${{ needs.build_artifacts.outputs.artifact-name }}
 
-  deploy_to_pypi_prod:
+  deploy_to_pypi_prod_after_test:
+    needs: [build_artifacts, deploy_to_pypi_test]
+    if: ${{ github.event.inputs.deploy_to_test == 'true' }}
+    uses: ./.github/workflows/deploy_to_pypi.yml
+    with:
+      package-version: ${{ needs.build_artifacts.outputs.package-version }}
+      target-environment: 'pypi-prod'
+      artifact-name: ${{ needs.build_artifacts.outputs.artifact-name }}
+
+  deploy_to_pypi_prod_direct:
     needs: [build_artifacts]
+    if: ${{ github.event.inputs.deploy_to_test != 'true' }}
     uses: ./.github/workflows/deploy_to_pypi.yml
     with:
       package-version: ${{ needs.build_artifacts.outputs.package-version }}


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Revise the CI workflow to allow conditional deployment to PyPi production either directly or after a test deployment, based on user input. Remove commented-out code related to OIDC debugging and attestations.

CI:
- Update the deploy workflow to include separate jobs for deploying to PyPi production directly or after testing, based on the input parameter 'deploy_to_test'.

<!-- Generated by sourcery-ai[bot]: end summary -->