### PR TITLE
Disable attestations in PyPI deployment workflow

### DIFF
--- a/.github/workflows/deploy_to_pypi.yml
+++ b/.github/workflows/deploy_to_pypi.yml
@@ -64,7 +64,7 @@ jobs:
           packages-dir: ${{ steps.download-artifact.outputs.download-path }}
           verbose: true
           print-hash: true
-          # attestations: true  # https://github.com/pypi/warehouse/issues/11096
+          attestations: false  # https://github.com/pypi/warehouse/issues/11096
 
 
     


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Set attestations to false in the deploy_to_pypi.yml workflow due to an issue with PyPI warehouse.