### PR TITLE
Add support for Python 3.13, update .gitignore, remove duplicate path to prod from workflow

### DIFF
--- a/.github/workflows/deploy_build_artifact.yaml
+++ b/.github/workflows/deploy_build_artifact.yaml
@@ -36,7 +36,8 @@ jobs:
       - name: install poetry
         uses: snok/install-poetry@v1 # v1
         with:
-          version: 1.8.3 # pin the version as they keep changing their APIs
+          # use latest poetry version
+          # version: 1.8.3 # pin the version as they keep changing their APIs
           virtualenvs-create: false
           virtualenvs-in-project: false
 

--- a/.github/workflows/deploy_workflow_wrapper.yml
+++ b/.github/workflows/deploy_workflow_wrapper.yml
@@ -27,16 +27,6 @@ jobs:
       target-environment: 'pypi-test'
       artifact-name: ${{ needs.build_artifacts.outputs.artifact-name }}
 
-  ## only deploy to either prod or test, not both
-  # deploy_to_pypi_prod_after_test:
-  #   needs: [build_artifacts, deploy_to_pypi_test]
-  #   if: ${{ github.event.inputs.deploy_to_test == 'true' }}
-  #   uses: ./.github/workflows/deploy_to_pypi.yml
-  #   with:
-  #     package-version: ${{ needs.build_artifacts.outputs.package-version }}
-  #     target-environment: 'pypi-prod'
-  #     artifact-name: ${{ needs.build_artifacts.outputs.artifact-name }}
-
   deploy_to_pypi_prod_direct:
     needs: [build_artifacts]
     if: ${{ github.event.inputs.deploy_to_test != 'true' }}

--- a/.github/workflows/deploy_workflow_wrapper.yml
+++ b/.github/workflows/deploy_workflow_wrapper.yml
@@ -27,14 +27,15 @@ jobs:
       target-environment: 'pypi-test'
       artifact-name: ${{ needs.build_artifacts.outputs.artifact-name }}
 
-  deploy_to_pypi_prod_after_test:
-    needs: [build_artifacts, deploy_to_pypi_test]
-    if: ${{ github.event.inputs.deploy_to_test == 'true' }}
-    uses: ./.github/workflows/deploy_to_pypi.yml
-    with:
-      package-version: ${{ needs.build_artifacts.outputs.package-version }}
-      target-environment: 'pypi-prod'
-      artifact-name: ${{ needs.build_artifacts.outputs.artifact-name }}
+  ## only deploy to either prod or test, not both
+  # deploy_to_pypi_prod_after_test:
+  #   needs: [build_artifacts, deploy_to_pypi_test]
+  #   if: ${{ github.event.inputs.deploy_to_test == 'true' }}
+  #   uses: ./.github/workflows/deploy_to_pypi.yml
+  #   with:
+  #     package-version: ${{ needs.build_artifacts.outputs.package-version }}
+  #     target-environment: 'pypi-prod'
+  #     artifact-name: ${{ needs.build_artifacts.outputs.artifact-name }}
 
   deploy_to_pypi_prod_direct:
     needs: [build_artifacts]

--- a/.github/workflows/test_run_pytest.yml
+++ b/.github/workflows/test_run_pytest.yml
@@ -15,7 +15,7 @@ jobs:
   test:
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4 # v4

--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,45 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+### MacOS
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### VSCode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pydantic-tfl-api"
-version = "1.2.1"
+version = "1.2.2"
 description = "A Pydantic-based wrapper for the TfL Unified API https://api.tfl.gov.uk/. Not associated with or endorsed by TfL."
 authors = ["Rob Aleck <mnbf9rca@users.noreply.github.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pydantic-tfl-api"
-version = "1.2.0"
+version = "1.2.1"
 description = "A Pydantic-based wrapper for the TfL Unified API https://api.tfl.gov.uk/. Not associated with or endorsed by TfL."
 authors = ["Rob Aleck <mnbf9rca@users.noreply.github.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "pydantic-tfl-api"
 version = "1.2.2"
-description = "A Pydantic-based wrapper for the TfL Unified API https://api.tfl.gov.uk/. Not associated with or endorsed by TfL."
+description = "A Pydantic-based wrapper for the TfL Unified API https://api-portal.tfl.gov.uk/. Not associated with or endorsed by TfL."
 authors = ["Rob Aleck <mnbf9rca@users.noreply.github.com>"]
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION
## Summary by Sourcery

Add support for Python 3.13 in the test workflow, update the .gitignore file, and remove a duplicate deployment path to production in the CI workflow.

CI:
- Remove duplicate deployment path to production in the deploy workflow.

Chores:
- Update .gitignore file.