### PR TITLE
fix(workflows): add bump-version environment to access GitHub App credentials

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -31,6 +31,7 @@ permissions:
 jobs:
   bump_version:
     runs-on: ubuntu-latest
+    environment: bump-version
     outputs:
       new_version: ${{ steps.bump_version.outputs.new_tag }}
 

--- a/.github/workflows/sync_release.yml
+++ b/.github/workflows/sync_release.yml
@@ -21,6 +21,7 @@ permissions:
 jobs:
   sync_branches:
     runs-on: ubuntu-latest
+    environment: bump-version
     outputs:
       synced: ${{ steps.sync_result.outputs.synced }}
 


### PR DESCRIPTION
## Summary
Fixes the workflow authentication error where the GitHub App credentials were not accessible.

## Problem
The `PUSH_APP_SECRET` is scoped to the "bump-version" environment, but our workflows weren't declaring they need this environment, causing authentication failures:
```
Error: [@octokit/auth-app] privateKey option is required
```

## Solution
Added `environment: bump-version` declaration to both jobs that need the GitHub App token:
- `sync_branches` job in `sync_release.yml`
- `bump_version` job in `bump_version.yml`

## Changes
- `.github/workflows/sync_release.yml`: Add environment declaration to sync_branches job
- `.github/workflows/bump_version.yml`: Add environment declaration to bump_version job

## Testing
Workflows will now be able to access the environment-scoped `PUSH_APP_SECRET` and authenticate properly to push to protected branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)