### PR TITLE
fix(workflow): remove broken workflow_run trigger for manual-only deployment

### DIFF
--- a/.github/workflows/deploy_build_artifact.yaml
+++ b/.github/workflows/deploy_build_artifact.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: check out code
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
-          fetch-depth: 1
+          fetch-depth: 0  # Fetch all history including tags for validation
 
       - name: Install uv
         uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3.2.4
@@ -44,6 +44,32 @@ jobs:
 
       - name: Install dependencies
         run: uv sync --all-extras --dev
+
+      - name: Extract version and validate tag exists
+        id: validate_version
+        run: |
+          # Extract version from pyproject.toml
+          VERSION=$(uv run python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Extracted version: $VERSION"
+
+          # Check if git tag exists for this version
+          if git show-ref --tags --verify --quiet "refs/tags/$VERSION"; then
+            echo "✅ Git tag '$VERSION' exists"
+          else
+            echo "❌ ERROR: Git tag '$VERSION' does not exist!"
+            echo ""
+            echo "This workflow requires that a git tag matching the version in pyproject.toml"
+            echo "already exists before building and publishing."
+            echo ""
+            echo "Please run the version bump workflow first:"
+            echo "  gh workflow run bump_version.yml --ref release"
+            echo ""
+            echo "Or if you need to create the tag manually:"
+            echo "  git tag $VERSION"
+            echo "  git push origin $VERSION"
+            exit 1
+          fi
 
       - name: Lint with ruff
         run: |
@@ -58,11 +84,11 @@ jobs:
       - name: Build
         id: Build
         run: |
-          version=$(uv run python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
-          echo "version is $version"
-          echo "version=$version" >> "$GITHUB_OUTPUT"
+          VERSION="${{ steps.validate_version.outputs.version }}"
+          echo "Building version $VERSION"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-          artifact_name="dist-$version"
+          artifact_name="dist-$VERSION"
           echo "artifact_name is $artifact_name"
           echo "artifact_name=$artifact_name" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/deploy_workflow_wrapper.yml
+++ b/.github/workflows/deploy_workflow_wrapper.yml
@@ -9,13 +9,6 @@ on:
         required: false
         default: false
 
-  workflow_run:
-    workflows: ["bump version"]
-    types:
-      - completed
-    branches:
-      - release  # Only trigger from release branch
-
 jobs:
   build_artifacts:
     uses: ./.github/workflows/deploy_build_artifact.yaml


### PR DESCRIPTION
## Summary
Two improvements to the deployment workflow for better safety and control:

1. **Remove broken automatic trigger** - Makes PyPI deployment manual-only
2. **Add git tag validation** - Prevents builds without proper version tagging

## Changes

### Remove `workflow_run` trigger
- The `workflow_run` trigger in `deploy_workflow_wrapper.yml` had a case mismatch ("bump version" vs "Bump Version") and wasn't working
- Removed it entirely since manual control over PyPI deployment is preferred
- Workflow now only runs via `workflow_dispatch` (manual trigger)

### Add tag existence validation
- New validation step in `deploy_build_artifact.yaml` checks that a git tag exists matching the version in `pyproject.toml`
- Fails early with clear error message if tag is missing
- Provides instructions on how to fix (run `bump_version.yml` or manually create tag)
- Changed `fetch-depth: 0` to retrieve all tags for validation

## Benefits
- ✅ **Full control**: Choose when to deploy and which PyPI instance (test vs prod)
- ✅ **Safety**: Can't accidentally build/publish without proper version bump
- ✅ **Enforces workflow order**: bump_version.yml → deploy_workflow_wrapper.yml
- ✅ **Clear error messages**: Guides users to fix issues

## Testing
The tag validation will:
- ✅ Pass when tag exists (normal case after bump_version workflow)
- ❌ Fail with helpful message when tag is missing

## How to Use (after merge)
```bash
# Deploy to PyPI production
gh workflow run deploy_workflow_wrapper.yml --ref release

# Deploy to PyPI-test
gh workflow run deploy_workflow_wrapper.yml --ref release -f deploy_to_test=true
```