### PR TITLE
feat(workflow): restrict deployment workflow to release branch only

### DIFF
--- a/.github/workflows/deploy_workflow_wrapper.yml
+++ b/.github/workflows/deploy_workflow_wrapper.yml
@@ -10,7 +10,29 @@ on:
         default: false
 
 jobs:
+  validate_branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate workflow is running on release branch
+        run: |
+          if [ "${{ github.ref_name }}" != "release" ]; then
+            echo "❌ ERROR: This workflow can only run on the 'release' branch!"
+            echo ""
+            echo "Current branch: ${{ github.ref_name }}"
+            echo "Required branch: release"
+            echo ""
+            echo "This is a safety measure to prevent accidental deployments from non-release branches."
+            echo ""
+            echo "To deploy, please:"
+            echo "  1. Ensure your changes are merged to main"
+            echo "  2. Run: gh workflow run sync_release.yml"
+            echo "  3. After sync completes, run: gh workflow run deploy_workflow_wrapper.yml --ref release"
+            exit 1
+          fi
+          echo "✅ Running on release branch"
+
   build_artifacts:
+    needs: [validate_branch]
     uses: ./.github/workflows/deploy_build_artifact.yaml
 
   deploy_to_pypi_test:

--- a/.github/workflows/deploy_workflow_wrapper.yml
+++ b/.github/workflows/deploy_workflow_wrapper.yml
@@ -9,35 +9,46 @@ on:
         required: false
         default: false
 
+env:
+  RELEASE_BRANCH: release
+
 jobs:
   validate_branch:
     runs-on: ubuntu-latest
+    if: github.ref_name == 'release'
     steps:
-      - name: Validate workflow is running on release branch
+      - name: Confirm running on release branch
         run: |
-          if [ "${{ github.ref_name }}" != "release" ]; then
-            echo "❌ ERROR: This workflow can only run on the 'release' branch!"
-            echo ""
-            echo "Current branch: ${{ github.ref_name }}"
-            echo "Required branch: release"
-            echo ""
-            echo "This is a safety measure to prevent accidental deployments from non-release branches."
-            echo ""
-            echo "To deploy, please:"
-            echo "  1. Ensure your changes are merged to main"
-            echo "  2. Run: gh workflow run sync_release.yml"
-            echo "  3. After sync completes, run: gh workflow run deploy_workflow_wrapper.yml --ref release"
-            exit 1
-          fi
-          echo "✅ Running on release branch"
+          echo "✅ Running on ${{ env.RELEASE_BRANCH }} branch"
+          echo "Current branch: ${{ github.ref_name }}"
+
+  check_wrong_branch:
+    runs-on: ubuntu-latest
+    if: github.ref_name != 'release'
+    steps:
+      - name: Fail if not on release branch
+        run: |
+          echo "❌ ERROR: This workflow can only run on the '${{ env.RELEASE_BRANCH }}' branch!"
+          echo ""
+          echo "Current branch: ${{ github.ref_name }}"
+          echo "Required branch: ${{ env.RELEASE_BRANCH }}"
+          echo ""
+          echo "This is a safety measure to prevent accidental deployments from non-release branches."
+          echo ""
+          echo "To deploy, please:"
+          echo "  1. Ensure your changes are merged to main"
+          echo "  2. Run: gh workflow run sync_release.yml"
+          echo "  3. After sync completes, run: gh workflow run deploy_workflow_wrapper.yml --ref ${{ env.RELEASE_BRANCH }}"
+          exit 1
 
   build_artifacts:
     needs: [validate_branch]
+    if: github.ref_name == 'release'
     uses: ./.github/workflows/deploy_build_artifact.yaml
 
   deploy_to_pypi_test:
-    needs: [build_artifacts]
-    if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_to_test == 'true' }}
+    needs: [validate_branch, build_artifacts]
+    if: github.ref_name == 'release' && github.event.inputs.deploy_to_test == 'true'
     uses: ./.github/workflows/deploy_to_pypi.yml
     with:
       package-version: ${{ needs.build_artifacts.outputs.package-version }}
@@ -45,8 +56,8 @@ jobs:
       artifact-name: ${{ needs.build_artifacts.outputs.artifact-name }}
 
   deploy_to_pypi_prod_direct:
-    needs: [build_artifacts]
-    if: ${{ github.event.inputs.deploy_to_test != 'true' }}
+    needs: [validate_branch, build_artifacts]
+    if: github.ref_name == 'release' && github.event.inputs.deploy_to_test != 'true'
     uses: ./.github/workflows/deploy_to_pypi.yml
     with:
       package-version: ${{ needs.build_artifacts.outputs.package-version }}


### PR DESCRIPTION
## Summary
Adds branch validation to ensure the deployment workflow can **only** run on the `release` branch, preventing accidental deployments from other branches.

## Changes

### New `validate_branch` job
- Checks that `github.ref_name == 'release'`
- Runs before any build or deployment jobs
- Fails immediately with clear error message if run from wrong branch
- Provides step-by-step instructions on proper workflow

### Updated job dependencies
- `build_artifacts` now depends on `validate_branch` passing
- Prevents wasted resources if branch check fails

## Benefits
- 🛡️ **Safety**: Impossible to accidentally deploy from main or feature branches
- 🎯 **Enforces workflow**: Must sync main → release → deploy
- 📝 **Clear guidance**: Error message explains what to do
- ⚡ **Fast failure**: Validates branch before spending time building

## Example Error Message
If someone tries to run from `main`:
```
❌ ERROR: This workflow can only run on the 'release' branch!

Current branch: main
Required branch: release

This is a safety measure to prevent accidental deployments from non-release branches.

To deploy, please:
  1. Ensure your changes are merged to main
  2. Run: gh workflow run sync_release.yml
  3. After sync completes, run: gh workflow run deploy_workflow_wrapper.yml --ref release
```

## Testing
- ✅ Running from `release` branch → workflow proceeds normally
- ❌ Running from any other branch → immediate failure with helpful message

## Usage
```bash
# ✅ Correct - will work
gh workflow run deploy_workflow_wrapper.yml --ref release

# ❌ Wrong - will fail with error
gh workflow run deploy_workflow_wrapper.yml --ref main
```

## Summary by Sourcery

Restrict the deployment workflow to run exclusively on the release branch by introducing a branch validation job and updating job dependencies.

New Features:
- Add validate_branch job to enforce running the deployment workflow only on the release branch.

Enhancements:
- Require build_artifacts job to depend on the validate_branch check to avoid wasted resources.

CI:
- Restrict deployment workflow to the release branch and provide a clear error message with usage instructions on failure.