### PR TITLE
chore(deps): update github-tag-action from v1.70.0 to v1.75.0

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Bump version and create tag
         id: bump_version
-        uses: anothrNick/github-tag-action@777684df761b882a3f4f70db16ac70d8cc78d0ea # v1.70.0
+        uses: anothrNick/github-tag-action@4ed44965e0db8dab2b466a16da04aec3cc312fd8
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           WITH_V: false


### PR DESCRIPTION
## Summary
- Updates `anothrNick/github-tag-action` from v1.70.0 to v1.75.0
- Resolves Renovate digest lookup issue preventing dependency updates
- Uses pinned commit SHA `4ed44965e0db8dab2b466a16da04aec3cc312fd8` for security

## Test plan
- [x] Verify workflow file syntax is valid
- [ ] Monitor next version bump workflow run to ensure action works correctly
- [ ] Confirm Renovate can now track this dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Chores:
- Update anothrNick/github-tag-action from v1.70.0 to pinned commit SHA 4ed44965e0db8dab2b466a16da04aec3cc312fd8 (v1.75.0)