### PR TITLE
chore: add py.typed marker file and update build configuration

### DIFF
--- a/pydantic_tfl_api/py.typed
+++ b/pydantic_tfl_api/py.typed
@@ -1,0 +1,2 @@
+# Marker file for PEP 561
+# This package contains inline type annotations and supports type checking

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,21 @@ release = [
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.build.targets.wheel]
+packages = ["pydantic_tfl_api"]
+
+[tool.hatch.build.targets.wheel.shared-data]
+"pydantic_tfl_api/py.typed" = "pydantic_tfl_api/py.typed"
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "/pydantic_tfl_api",
+    "/tests",
+    "/pyproject.toml",
+    "/README.md",
+    "/LICENSE",
+]
+
 [tool.coverage.run]
 source = ["pydantic_tfl_api"]
 omit = [


### PR DESCRIPTION
## Summary by Sourcery

Ensure the package is PEP 561 compliant by adding a py.typed marker and update Hatch build targets for wheel and sdist to include all necessary files

Build:
- Add py.typed marker file to declare the package as PEP 561 typed
- Configure hatchling wheel target to include the package and shared-data mapping for py.typed
- Extend hatchling sdist target to include the package directory, tests, and project metadata files